### PR TITLE
Fixed typographical error, changed aquisition to acquisition in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ TranslationUtility.changeStaticInstanceConfig("zh-cn");
 ### Why Translate
 1. Free advertising on foreign app stores
 2. Extend your reach to find new customers, who may respond to your app differently -- ie a soccer game in Spanish
-3. Potentially lower cost of aquisition and/or higher expected revenue per download [Distimo Publication - How the Most Successful Apps Monetize Globally](http://www.distimo.com/download/publication/Distimo_Publication_-_February_2014/EN/archive/)
+3. Potentially lower cost of acquisition and/or higher expected revenue per download [Distimo Publication - How the Most Successful Apps Monetize Globally](http://www.distimo.com/download/publication/Distimo_Publication_-_February_2014/EN/archive/)
 
 ### Potential issues confronted when localizing
 1. Getting strings out of your current app


### PR DESCRIPTION
@Transfluent, I've corrected a typographical error in the documentation of the [Transfluent-Unity](https://github.com/Transfluent/Transfluent-Unity) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.